### PR TITLE
Used classify to turn model into proper class name

### DIFF
--- a/lib/trucker.rb
+++ b/lib/trucker.rb
@@ -7,7 +7,7 @@ module Trucker
     unless options[:helper]
   
       # Grab model to migrate
-      model = name.to_s.singularize.capitalize
+      model = name.to_s.classify
   
       # Wipe out existing records
       model.constantize.delete_all


### PR DESCRIPTION
This change fixes an issue when using class names with underscores.

Eg. (this would fail)

rake db:migrate:foo_bar

Expected myapp/app/models/foo_bar.rb to define Foo_bar
