### PR TITLE
updates README and template for latest Rails syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,21 @@ Use Trucker to migrate legacy data into your Rails app.
 7. Custom your table name for each of your legacy models.
   ```ruby
   class LegacyPost < LegacyBase
-    set_table_name "LEGACY_TABLE_NAME_GOES_HERE"
+    self.table_name =  "LEGACY_TABLE_NAME_GOES_HERE"
   end
   ```
   
   Since you're migrating data from an old database, your table names may not 
   follow Rails conventions for database table naming. If so, you will need to 
-  set the `set_table_name` value for each of your legacy models to match the 
+  set the `self.table_name = ` value for each of your legacy models to match the 
   name of table from which you will be importing data.
   
   For instance, in the example above, if your old posts were stored in an 
-  `articles` table, you would customize `set_table_name` like so:
+  `articles` table, you would customize `self.table_name = ` like so:
   
   ```ruby
   class LegacyPost < LegacyBase
-    set_table_name "articles"
+    self.table_name =  "articles"
   end
   ```
   
@@ -77,7 +77,7 @@ Use Trucker to migrate legacy data into your Rails app.
 
   ```ruby
   class LegacyPost < LegacyBase
-    set_table_name "LEGACY_TABLE_NAME_GOES_HERE"
+    self.table_name =  "LEGACY_TABLE_NAME_GOES_HERE"
 
     def map
       {
@@ -100,7 +100,7 @@ Use Trucker to migrate legacy data into your Rails app.
 
   ```ruby
   class LegacyPost < LegacyBase
-    set_table_name "LEGACY_TABLE_NAME_GOES_HERE"
+    self.table_name =  "LEGACY_TABLE_NAME_GOES_HERE"
 
     def map
       {

--- a/generators/truck/templates/legacy_model.erb
+++ b/generators/truck/templates/legacy_model.erb
@@ -1,5 +1,5 @@
 class Legacy<%= model_name.classify %> < LegacyBase
-  set_table_name "<%= model_name.pluralize %>"
+  self.table_name =  "<%= model_name.pluralize %>"
 
   def map
     {


### PR DESCRIPTION
`set_table_name` was deprecated as of Rails 3.2.1 : http://apidock.com/rails/ActiveRecord/Base/set_table_name/class

This updates the docs. Thanks for your work on this gem!